### PR TITLE
Renomeando símbolos

### DIFF
--- a/conta.cpp
+++ b/conta.cpp
@@ -1,11 +1,10 @@
-#pragma once
 #include <iostream>
 #include "conta.hpp"
 
-int conta::NumeroDeContas = 0;
-conta::conta(std::string numero,Titular Titular):
+int Conta::NumeroDeContas = 0;
+Conta::Conta(std::string numero,Titular titular):
     numero(numero),
-    Titular(Titular),
+    titular(titular),
     saldo(0)
 {
 
@@ -13,7 +12,7 @@ conta::conta(std::string numero,Titular Titular):
 
 }
 
-void conta::sacar(float valor_a_sacar){
+void Conta::sacar(float valor_a_sacar){
 
  if (saldo<valor_a_sacar){
            std:: cout<<"nao tem como vc sacar menos do que vc tem !!" << std::endl;
@@ -21,7 +20,7 @@ void conta::sacar(float valor_a_sacar){
         }
         if(valor_a_sacar<0){
 
-           std::cout<<"não pode sacar um valor negativo"<< std::endl;
+           std::cout<<"nï¿½o pode sacar um valor negativo"<< std::endl;
             return;
         }
     saldo -= valor_a_sacar;
@@ -32,7 +31,7 @@ void conta::sacar(float valor_a_sacar){
 
 
 
-void conta::depositar(float valor_a_depositar){
+void Conta::depositar(float valor_a_depositar){
 
 
  if(valor_a_depositar<0){
@@ -44,14 +43,14 @@ void conta::depositar(float valor_a_depositar){
 
 }
 
-float conta::recupera_saldo()
+float Conta::recupera_saldo()
 {
     return saldo;
 }
 
 
 
-conta:: ~conta() 
+Conta:: ~Conta()
 {
 
     NumeroDeContas--;

--- a/conta.hpp
+++ b/conta.hpp
@@ -3,19 +3,19 @@
 #include <iostream>
 #include "titular.hpp"
 
-struct conta{
+struct Conta{
 private:
     std::string numero;
-    Titular Titular;
+    Titular titular;
     float saldo;
 
-public: 
-    conta(std::string numero,Titular Titular);
+public:
+    Conta(std::string numero,Titular titular);
     void sacar(float valor_a_sacar);
     void depositar(float valor_a_depositar);
     float recupera_saldo();
     static int NumeroDeContas;
-    ~conta();
-    
-    
+    ~Conta();
+
+
 };

--- a/main.cpp
+++ b/main.cpp
@@ -6,13 +6,13 @@ using namespace std;
 
 int main()
 {
-    
-    conta umaconta("12345","nicolas");
-    
-    umaconta.depositar(100);
-    umaconta.sacar(2);
- 
-    cout << umaconta.recupera_saldo() << endl;
-    
+    Titular um_titular("123.456.789-10", "nicolas");
+    Conta uma_conta("12345", um_titular);
+
+    uma_conta.depositar(100);
+    uma_conta.sacar(2);
+
+    cout << uma_conta.recupera_saldo() << endl;
+
     return 0;
 }


### PR DESCRIPTION
Renomeando símbolos para manter um padrão e corrigir o erro de compilação com conta::Titular